### PR TITLE
Fix wrong environment variables & typo in README

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -5,7 +5,7 @@ module.exports = {
         title: 'Codetribute'
       }
     }],
-    ['@neutrinojs/env', ['GITHUB_PERSONAL_ACCESS_TOKEN', 'NODE_ENV']],
+    ['@neutrinojs/env', ['GITHUB_PERSONAL_API_TOKEN', 'NODE_ENV']],
     (neutrino) => {
       neutrino.config.output.publicPath('/');
       neutrino.config.module

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get started with local development, create a file in the root of the repo nam
 `.env` with the following content. You can also set the variables in your shell environment.
 
 ```bash
-GITHUB_PERSONAL_ACCESS_TOKEN=<your_github_api_token>
+GITHUB_PERSONAL_API_TOKEN=<your_github_api_token>
 ```
 
 Generate a GitHub personal access token [here](https://github.com/settings/tokens). When prompted

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get started with local development, create a file in the root of the repo nam
 `.env` with the following content. You can also set the variables in your shell environment.
 
 ```bash
-GITHUB_PERSONAL_API_TOKEN=<your_github_api_token>
+GITHUB_PERSONAL_ACCESS_TOKEN=<your_github_api_token>
 ```
 
 Generate a GitHub personal access token [here](https://github.com/settings/tokens). When prompted
@@ -45,7 +45,7 @@ about scopes, access to public repositories is the only one required.
 
 ### Tasks and Configuration
 
-Building this project uses [Neutrino](https://github.com/mozilla-neutrino/neutrino),
+Building this project uses [Neutrino](https://github.com/mozilla-neutrino/neutrino-dev),
 [neutrino-preset-mozilla-frontend-infra](https://github.com/mozilla-frontend-infra/neutrino-preset-mozilla-frontend-infra)
 
 ### Testing changes

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,7 @@ export default class App extends Component {
     link: new HttpLink({
       uri: 'https://api.github.com/graphql',
       headers: {
-        authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+        authorization: `Bearer ${process.env.GITHUB_PERSONAL_API_TOKEN}`,
       },
     }),
   });


### PR DESCRIPTION
## Changes
1. Fix wrong `.env` referencing. It should be `GITHUB_PERSONAL_API_TOKEN`
2. Fix broken link to Mozilla Neutrino

## Test Plan
1. Run the website in dev & able to use GitHub GraphQL API :white_check_mark:
2. Check link working correctly :white_check_mark:
