### PR TITLE
Make link in description inside ProjectCard works

### DIFF
--- a/src/components/ProjectCard/index.jsx
+++ b/src/components/ProjectCard/index.jsx
@@ -39,7 +39,7 @@ export default class ProjectCard extends Component {
     summary: null,
   };
 
-  handleTextClicked = event => {
+  handleSummaryClick = event => {
     if (event.target.href) {
       event.stopPropagation();
     }
@@ -61,7 +61,7 @@ export default class ProjectCard extends Component {
             {summary && (
               <Typography
                 className={classes.projectSummary}
-                onClick={this.handleTextClicked}>
+                onClick={this.handleSummaryClick}>
                 <Markdown source={summary} />
               </Typography>
             )}

--- a/src/components/ProjectCard/index.jsx
+++ b/src/components/ProjectCard/index.jsx
@@ -39,6 +39,12 @@ export default class ProjectCard extends Component {
     summary: null,
   };
 
+  handleTextClicked = event => {
+    if (event.target.href) {
+      event.stopPropagation();
+    }
+  };
+
   render() {
     const {
       classes,
@@ -53,7 +59,9 @@ export default class ProjectCard extends Component {
               {name}
             </Typography>
             {summary && (
-              <Typography className={classes.projectSummary}>
+              <Typography
+                className={classes.projectSummary}
+                onClick={this.handleTextClicked}>
                 <Markdown source={summary} />
               </Typography>
             )}


### PR DESCRIPTION
Previously, the link when clicked will direct us to the individual
project page, instead of the link itself.

Fix #33 