### PR TITLE
Add query string for sort on and sort direction

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lodash.uniqby": "^4.7.0",
     "mdi-react": "^3.4.0",
     "prop-types": "^15.6.1",
+    "qs": "^6.5.2",
     "ramda": "^0.25.0",
     "react": "^16.3.2",
     "react-apollo": "^2.1.4",

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -1,4 +1,4 @@
-import { compareDesc } from 'date-fns';
+import { compareAsc } from 'date-fns';
 import { or } from 'ramda';
 
 /**
@@ -19,7 +19,7 @@ const sort = (referenceElement, compareElement) => {
 
     return diff < 0 ? -1 : 1;
   } else if (Date.parse(referenceElement) || Date.parse(compareElement)) {
-    return compareDesc(referenceElement, compareElement);
+    return compareAsc(referenceElement, compareElement);
   } else if (
     referenceElement.match(/^\d+ -/) &&
     compareElement.match(/^\d+ -/)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8016,7 +8016,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@~6.5.1:
+qs@^6.5.2, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 


### PR DESCRIPTION
It uses location and history props. Also fix the sorting for date in utils.js since we already reverse the element before we call the function (https://github.com/mozilla-frontend-infra/codetribute/blob/master/src/components/TasksTable/index.jsx#L56), thus, we can use compareAsc

Fix #49