### PR TITLE
Add more text for Taskcluster

### DIFF
--- a/src/components/ProjectCard/index.jsx
+++ b/src/components/ProjectCard/index.jsx
@@ -18,7 +18,7 @@ import Markdown from 'react-markdown';
   textAlign: {
     textAlign: 'center',
   },
-  cardDescription: {
+  projectSummary: {
     fontWeight: 300,
     padding: 2 * theme.spacing.unit,
   },
@@ -30,19 +30,19 @@ export default class ProjectCard extends Component {
   static propTypes = {
     project: shape({
       name: string.isRequired,
-      description: string,
+      summary: string,
       fileName: string.isRequired,
     }).isRequired,
   };
 
   static defaultProps = {
-    description: null,
+    summary: null,
   };
 
   render() {
     const {
       classes,
-      project: { name, description, fileName },
+      project: { name, summary, fileName },
     } = this.props;
 
     return (
@@ -52,9 +52,9 @@ export default class ProjectCard extends Component {
             <Typography gutterBottom variant="title" component="h4">
               {name}
             </Typography>
-            {description && (
-              <Typography className={classes.cardDescription}>
-                <Markdown source={description} />
+            {summary && (
+              <Typography className={classes.projectSummary}>
+                <Markdown source={summary} />
               </Typography>
             )}
           </CardContent>

--- a/src/data/a11y.yaml
+++ b/src/data/a11y.yaml
@@ -1,5 +1,5 @@
 name: Accessibility
-description: Get involved with the [Accessibility](https://wiki.mozilla.org/Accessibility/Contribute) team
+summary: Get involved with the [Accessibility](https://wiki.mozilla.org/Accessibility/Contribute) team
 products: 
  - Core: ['Disability Access APIs']
  - Firefox: ['Disability Access']

--- a/src/data/appsengineering.yaml
+++ b/src/data/appsengineering.yaml
@@ -1,4 +1,4 @@
 name: Apps Engineering
-description: Get involved with the [Apps Engineering team](https://wiki.mozilla.org/Apps/Engineering)
+summary: Get involved with the [Apps Engineering team](https://wiki.mozilla.org/Apps/Engineering)
 products: 
  - Developer Ecosystem: ['App Center', 'Apps', 'Dev Kit', 'Web Components']

--- a/src/data/bugzilla.yaml
+++ b/src/data/bugzilla.yaml
@@ -1,5 +1,5 @@
 name: Bugzilla
-description: Get involved with the [Bugzilla](https://wiki.mozilla.org/Bugzilla) project or [BMO](https://wiki.mozilla.org/BMO), Mozilla's custom version
+summary: Get involved with the [Bugzilla](https://wiki.mozilla.org/Bugzilla) project or [BMO](https://wiki.mozilla.org/BMO), Mozilla's custom version
 products: 
  - Bugzilla: ['Administration', 'Attachments & Requests', 'Bug Import/Export & Moving', 'Bugzilla-General', 'bugzilla.org', 'Creating/Changing Bugs', 'Documentation', 'Email Notifications', 'Extensions', 'QA Test Scripts', 'Query/Bug Lists', 'Testing Suite', 'User Accounts', 'User Interface', 'WebService', 'Whining']
  - bugzilla.mozilla.org: ['Administration', 'API', 'Bugzilla Tweaks', 'Developer Box', 'Extensions: AntiSpam', 'Extensions: BMO', 'Extensions: ComponentWatching', 'Extensions: MyDashboard', 'Extensions: Needinfo', 'Extensions: UserProfile', 'General', 'rbbz', 'Sandstone/Mozilla Skin', 'User Interface']

--- a/src/data/devtools.yaml
+++ b/src/data/devtools.yaml
@@ -1,4 +1,4 @@
 name: Firefox - Developer Tools
-description: Get involved with the [devtools team](https://wiki.mozilla.org/DevTools/GetInvolved)
+summary: Get involved with the [devtools team](https://wiki.mozilla.org/DevTools/GetInvolved)
 products: 
  - Firefox: ['Developer Tools', 'Developer Tools: 3D View', 'Developer Tools: App Manager', 'Developer Tools: Console', 'Developer Tools: Debugger', 'Developer Tools: Framework', 'Developer Tools: Graphic Commandline and Toolbar', 'Developer Tools: Inspector', 'Developer Tools: Netmonitor', 'Developer Tools: Object Inspector', 'Developer Tools: Profiler', 'Developer Tools: Responsive Mode', 'Developer Tools: Scratchpad', 'Developer Tools: Source Editor', 'Developer Tools: Style Editor']

--- a/src/data/gfx.yaml
+++ b/src/data/gfx.yaml
@@ -1,4 +1,4 @@
 name: Graphics
-description: Get involved with the [Graphics](https://wiki.mozilla.org/Platform/GFX/Contribute) team
+summary: Get involved with the [Graphics](https://wiki.mozilla.org/Platform/GFX/Contribute) team
 products: 
  - Core: ['Graphics', 'GFX: Color Management', 'Canvas: WebGL', 'Canvas: 2D', 'ImageLib', 'Graphics', 'Graphics: Layers', 'Graphics: Text', 'Panning and Zooming']

--- a/src/data/instantbird.yaml
+++ b/src/data/instantbird.yaml
@@ -1,5 +1,5 @@
 name: Instantbird
-description: Get involved with the [Instantbird project](https://wiki.instantbird.org/Main_Page)
+summary: Get involved with the [Instantbird project](https://wiki.instantbird.org/Main_Page)
 products: 
  - Instantbird
  - Chat Core

--- a/src/data/jseng.yaml
+++ b/src/data/jseng.yaml
@@ -1,4 +1,4 @@
 name: JavaScript Engine
-description: Get involved with the [JS engine](https://wiki.mozilla.org/JavaScript:New_to_SpiderMonkey) team
+summary: Get involved with the [JS engine](https://wiki.mozilla.org/JavaScript:New_to_SpiderMonkey) team
 products: 
  - Core: ['JavaScript Engine', 'JavaScript Engine: JIT', 'JavaScript: GC', 'JavaScript: Internationalization API', 'JavaScript: Standard Library', 'js-ctypes', 'XPConnect']

--- a/src/data/mdn.yaml
+++ b/src/data/mdn.yaml
@@ -1,4 +1,4 @@
 name: MDN / Developer Documentation
-description: Get involved with the [MDN Community](https://developer.mozilla.org/en-US/docs/MDN/Getting_started)
+summary: Get involved with the [MDN Community](https://developer.mozilla.org/en-US/docs/MDN/Getting_started)
 products: 
  - Developer Documentation: ['Accessibility', 'Add-ons', 'API: CSSOM', 'API: Device API', 'API: DOM', 'API: File API', 'API: HTML', 'API: IndexedDB', 'API: Miscellaneous', 'API: SVG', 'API: Web Animations', 'API: Web Audio', 'API: Web Sockets', 'API: Web Workers', 'API: WebRTC', 'Apps', 'CSS', 'Developer Tools', 'Emscripten', 'Games', 'General', 'HTML', 'JavaScript', 'Learning Area', 'Localization', 'Macros/Templates', 'Marketplace', 'MathML', 'MDN Meta Docs', 'Mozilla Platform', 'Protocols', 'Security', 'SVG']

--- a/src/data/mobileandroid.yaml
+++ b/src/data/mobileandroid.yaml
@@ -1,5 +1,5 @@
 name: Firefox - Mobile (Android)
-description: Get involved with the [Mobile team](https://wiki.mozilla.org/Mobile/Get_Involved)
+summary: Get involved with the [Mobile team](https://wiki.mozilla.org/Mobile/Get_Involved)
 products: 
  - Fennec
  - Firefox for Android

--- a/src/data/mobileios.yaml
+++ b/src/data/mobileios.yaml
@@ -1,4 +1,4 @@
 name: Firefox - Mobile (iOS)
-description: Find out more at the [GitHub page](https://github.com/mozilla/firefox-ios)
+summary: Find out more at the [GitHub page](https://github.com/mozilla/firefox-ios)
 products: 
  - Firefox for iOS

--- a/src/data/releng.yaml
+++ b/src/data/releng.yaml
@@ -1,5 +1,5 @@
 name: Release Engineering
-description: Get involved with the [Release Engineering](https://wiki.mozilla.org/ReleaseEngineering/Contribute) team
+summary: Get involved with the [Release Engineering](https://wiki.mozilla.org/ReleaseEngineering/Contribute) team
 products: 
  - mozilla.org: ['Hg: Customizations']
  - Release Engineering

--- a/src/data/reporting.yaml
+++ b/src/data/reporting.yaml
@@ -1,4 +1,4 @@
 name: Dashboards and Reporting
-description: Find out more about the [Treeherder](https://github.com/mozilla/treeherder) dashboard and its components
+summary: Find out more about the [Treeherder](https://github.com/mozilla/treeherder) dashboard and its components
 products: 
  - Tree Management

--- a/src/data/seamonkey.yaml
+++ b/src/data/seamonkey.yaml
@@ -1,4 +1,4 @@
 name: SeaMonkey
-description: Get involved with the [SeaMonkey Project](http://www.seamonkey-project.org)
+summary: Get involved with the [SeaMonkey Project](http://www.seamonkey-project.org)
 products: 
  - SeaMonkey

--- a/src/data/servo.yaml
+++ b/src/data/servo.yaml
@@ -1,4 +1,4 @@
 name: Servo
-description: Get involved with the [Servo](https://github.com/servo/servo/) project
+summary: Get involved with the [Servo](https://github.com/servo/servo/) project
 repositories: 
  - servo/servo: E-easy

--- a/src/data/sync.yaml
+++ b/src/data/sync.yaml
@@ -1,5 +1,5 @@
 name: Firefox - Sync
-description: Get involved with the [Sync](https://wiki.mozilla.org/Services/Sync#Get_Involved) team
+summary: Get involved with the [Sync](https://wiki.mozilla.org/Services/Sync#Get_Involved) team
 products: 
  - Cloud Services: ['Firefox Sync: Backend', 'Firefox Sync: Build', 'Firefox Sync: Crypto', 'Firefox Sync: UI', 'Server: Sync']
  - Firefox: ['Sync']

--- a/src/data/taskcluster.yaml
+++ b/src/data/taskcluster.yaml
@@ -1,3 +1,50 @@
-name: TaskCluster
+name: Taskcluster
+summary: Taskcluster is Mozilla's platform for building, testing, and releasing software.
+introduction: |
+  ## About Taskcluster
+ 
+  Taskcluster is a distributed platform for executing tasks, such as running tests.
+  Every day, it runs hundreds of thousands of tasks to support Firefox and lots of other projects at Mozilla.
+  It is written in Javascript and Go and has lots of opportunities to help out.
+
+  You can learn a bit about Taskcluster in its [documentation](http://docs.taskcluster.net/) -- the tutorial makes a good place to start.
+
+  ## Who Works on Taskcluster?
+
+  Many of the project participants, past and present, are listed on [our people page](https://docs.taskcluster.net/docs/people).
+  The team assigned to work on Taskcluster at Mozilla is about 10 people, distributed around Europe, North America, and South America.
+  You will likely see the names of team members listed as mentors in the bugs and issues on this site.
+  We are always excited to meet new Mozillians!
+
+  ## How Do I Get Started?
+
+  If you are working on a bug (in Bugzilla), you may need to [create a new account](https://bugzilla.mozilla.org/createaccount.cgi).
+  If you are working on an issue (in Github), you will need a Github account.
+
+  Comment in the bug or issue to say that you are working on it, and ask any questions that you have at that time.
+  But do your research!
+  Look the other comments, look at the documentation and source code, and try to figure out as much as you can first.
+  This helps you learn more about Taskcluster and understand better the bug you're fixing or feature you're adding.
+
+  ### How Do I Write the Code?
+ 
+  All of the Taskcluster code is in Github repositories in the [taskcluster organization](https://github.com/taskcluster).
+  For example, the queue service is in the [taskcluster-queue](https://github.com/taskcluster/taskcluster-queue) repository.
+  Once you've figured out which repository to use, clone it and -- before you change anything -- run the tests.
+  The repository's README file will describe how to set up and run tests.
+
+  From there, follow the Github pull-request process: make a fork of the repository, make your changes on a branch, and then create a pull request from that branch.
+  The Internet is full of guides for this process, and of course we are happy to help as well.
+
+  ## How Do I Get Help?
+
+  The best place to talk about a bug or issue is in the comments.
+  Don't be afraid to ask questions or describe how you are solving the problem.
+  That way, anyone watching the bug can answer your questions or offer useful advice.
+  Each bug has a mentor, and that person will usually be the one to reply.
+
+  We are also available on [irc](https://wiki.mozilla.org/IRC) in the `#taskcluster-contributors` channel.
+  That's a great place to get quick help or work through issues with Git or Node.
+
 products: 
- - TaskCluster
+ - Taskcluster

--- a/src/data/webmaker.yaml
+++ b/src/data/webmaker.yaml
@@ -1,5 +1,5 @@
 name: Webmaker
-description: Get involved with the [Webmaker team](http://webmaker.org)
+summary: Get involved with the [Webmaker team](http://webmaker.org)
 products: 
  - Webmaker: ['Badges', 'Community', 'DevOps', 'Events', 'General', 'Login', 'MakeAPI', 'Marketing', 'Popcorn Maker', 'Projects', 'Thimble', 'popcorn.js', 'webmaker.org']
 repositories: 

--- a/src/views/Project/index.jsx
+++ b/src/views/Project/index.jsx
@@ -5,6 +5,7 @@ import dotProp from 'dot-prop-immutable';
 import { mergeAll } from 'ramda';
 import uniqBy from 'lodash.uniqby';
 import Typography from '@material-ui/core/Typography';
+import Markdown from 'react-markdown';
 import projects from '../../data/loader';
 import Spinner from '../../components/Spinner';
 import ErrorPanel from '../../components/ErrorPanel';
@@ -118,6 +119,11 @@ export default class Project extends Component {
           <Typography variant="subheading" align="center">
             Bugs & Issues
           </Typography>
+          {project.introduction && (
+            <Typography variant="body1">
+              <Markdown source={project.introduction} />
+            </Typography>
+          )}
           {data && data.error && <ErrorPanel error={data.error} />}
           {loading && <Spinner />}
           {!loading && <TasksTable items={issues} />}


### PR DESCRIPTION
This splits the `description` into `summary` (on the project card) and `introduction` (on the project page).

I wrote an introduction for Taskcluster -- please edit it mercilessly /cc @helfi92!

I also did a very poor job of including the introduction in the project page -- it shows up as white-on-white text.  I'm happy to have advice about how to fix that, or I can land it as-is for fixing in a later PR.