### PR TITLE
Handle label with space for GH issue

### DIFF
--- a/src/views/Project/index.jsx
+++ b/src/views/Project/index.jsx
@@ -109,7 +109,7 @@ export default class Project extends Component {
       Object.entries(tagsMapping).map(([tag, repos]) => {
         const searchQuery = [
           repos.map(repo => `repo:${repo}`).join(' '),
-          `label:${tag}`,
+          `label:"${tag}"`,
           'state:open',
         ].join(' ');
 


### PR DESCRIPTION
Use double quotes before and after the label, regardless of whether
it contains space or not

Closes #85