### PR TITLE
Remove telemetry-dashboard from internals

### DIFF
--- a/src/data/internals.yaml
+++ b/src/data/internals.yaml
@@ -4,5 +4,4 @@ products:
  - NSPR
  - NSS
  - Toolkit: ['Telemetry', 'Add-ons Manager']
-repositories: 
- - mozilla/telemetry-dashboard: mentored
+ 


### PR DESCRIPTION
The Telemetry Dashboard is not part of Firefox code and already covered in the `internals-telemetry-dashboard.yaml` file.