### PR TITLE
Fix drawer open in chrome and mobile

### DIFF
--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -251,7 +251,7 @@ export default class TasksTable extends Component {
     this.setQuery({});
   };
 
-  handleDrawerOpen = ({ target: { name } }) => {
+  handleDrawerOpen = ({ currentTarget: { name } }) => {
     memoizeWith(
       name => name,
       name =>


### PR DESCRIPTION
Use currentTarget instead of target : based on this https://github.com/mui-org/material-ui/issues/7974

Fix #130