### PR TITLE
Add Rust projects

### DIFF
--- a/src/data/cargo.yaml
+++ b/src/data/cargo.yaml
@@ -1,4 +1,4 @@
-name: cargo
+name: Cargo
 summary: Cargo is Rust's build system
 repositories: 
  - rust-lang-nursery/rustfmt: E-Easy

--- a/src/data/cargo.yaml
+++ b/src/data/cargo.yaml
@@ -1,0 +1,4 @@
+name: cargo
+summary: Cargo is Rust's build system
+repositories: 
+ - rust-lang-nursery/rustfmt: E-Easy

--- a/src/data/clippy.yaml
+++ b/src/data/clippy.yaml
@@ -1,4 +1,4 @@
-name: clippy
+name: Clippy
 summary: Clippy is linter for Rust code
 repositories: 
  - rust-lang-nursery/rust-clippy: good first issue

--- a/src/data/clippy.yaml
+++ b/src/data/clippy.yaml
@@ -1,0 +1,4 @@
+name: clippy
+summary: Clippy is linter for Rust code
+repositories: 
+ - rust-lang-nursery/rust-clippy: good first issue

--- a/src/data/rls.yaml
+++ b/src/data/rls.yaml
@@ -1,0 +1,4 @@
+name: Rust Language Server
+summary: RLS is the IDE integration plugin for Rust
+repositories: 
+ - rust-lang-nursery/rls: good first issue

--- a/src/data/rust-bindgen.yaml
+++ b/src/data/rust-bindgen.yaml
@@ -1,0 +1,4 @@
+name: Rust bindgen
+summary: Tool for automatically generating Rust bindings for C/C++ APIs
+repositories: 
+ - rust-lang-nursery/rust-bindgen: E-easy

--- a/src/data/rust-cookbook.yaml
+++ b/src/data/rust-cookbook.yaml
@@ -1,0 +1,4 @@
+name: The Rust Cookbook
+summary: Work on bite-sized examples to get folks cooking with Rust
+repositories: 
+ - rust-lang-nursery/rust-cookbook: good first issue

--- a/src/data/rust.yaml
+++ b/src/data/rust.yaml
@@ -1,0 +1,4 @@
+name: Rust
+summary: Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.
+repositories: 
+ - rust-lang/rust: E-easy

--- a/src/data/rustfmt.yaml
+++ b/src/data/rustfmt.yaml
@@ -1,0 +1,4 @@
+name: rustfmt
+summary: Rustfmt is the automatic code formatter for Rust code
+repositories: 
+ - rust-lang-nursery/rustfmt: good-first-issue

--- a/src/data/rustfmt.yaml
+++ b/src/data/rustfmt.yaml
@@ -1,4 +1,4 @@
-name: rustfmt
+name: Rustfmt
 summary: Rustfmt is the automatic code formatter for Rust code
 repositories: 
  - rust-lang-nursery/rustfmt: good-first-issue


### PR DESCRIPTION
May also be worth linking to https://www.rustaceans.org/findwork

Is there a way I can mark these as Rust projects so that folks can filter by Rust to find bugs?