### PR TITLE
Combine build, DOM, editor, layout, media and networking into one project

### DIFF
--- a/src/data/build.yaml
+++ b/src/data/build.yaml
@@ -1,3 +1,0 @@
-name: Build System
-products:
- - MailNews Core: ['Build Config']

--- a/src/data/dom.yaml
+++ b/src/data/dom.yaml
@@ -1,3 +1,0 @@
-name: DOM and CSS technology
-products: 
- - Core: ['CSS Parsing and Computation', 'SVG', 'DOM', 'DOM: Core & HTML', 'DOM: CSS Object Model', 'DOM: Device Interfaces', 'DOM: Events', 'DOM: IndexedDB', 'DOM: Mozilla Extensions', 'DOM: Other', 'DOM: Traversal-Range', 'DOM: Validation', 'DOM: Workers', 'Geolocation', 'HTML: Form Submission', 'Event Handling', 'HTML: Parser', 'MathML', 'XML', 'XSLT']

--- a/src/data/editor.yaml
+++ b/src/data/editor.yaml
@@ -1,3 +1,0 @@
-name: Input handling
-products: 
- - Core: ['Editor', 'Selection', 'Keyboard: Navigation', 'Drag and Drop', 'Spelling Checker']

--- a/src/data/layout.yaml
+++ b/src/data/layout.yaml
@@ -1,3 +1,0 @@
-name: Layout
-products: 
- - Core: ['Layout', 'Layout: Block and Inline', 'Layout: Floats', 'Layout: Form Controls', 'Layout: HTML Frames', 'Layout: Images', 'Layout: Misc Code', 'Layout: R & A Pos', 'Layout: Tables', 'Layout: Text', 'Layout: View Rendering']

--- a/src/data/media.yaml
+++ b/src/data/media.yaml
@@ -1,3 +1,0 @@
-name: Media
-products: 
- - Core: ['Video/Audio', 'WebRTC', 'WebRTC: Audio/Video', 'WebRTC: Signalling']

--- a/src/data/net.yaml
+++ b/src/data/net.yaml
@@ -1,3 +1,0 @@
-name: Networking
-products: 
- - Core: ['Networking', 'Networking: HTTP', 'Networking: Cookies', 'Networking: File', 'Networking: JAR', 'Networking: WebSockets', 'Networking: DNS', 'WebRTC: Networking']

--- a/src/data/webplatform.yaml
+++ b/src/data/webplatform.yaml
@@ -1,0 +1,10 @@
+name: Web Platform
+summary: Web Platform consists of Networking, Layout, Build System, DOM & CSS Technology, Input Handling, and Media.
+products:
+ - Core: ['CSS Parsing and Computation', 'DOM', 'DOM: Core & HTML', 'DOM: CSS Object Model', 'DOM: Device Interfaces', 'DOM: Events', 'DOM: IndexedDB',
+ 'DOM: Mozilla Extensions', 'DOM: Other', 'DOM: Traversal-Range', 'DOM: Validation', 'DOM: Workers', 'Drag and Drop', 'Editor', 'Event Handling', 'Geolocation',
+ 'HTML: Form Submission', 'HTML: Parser', 'Keyboard: Navigation', 'Layout', 'Layout: Block and Inline', 'Layout: Floats', 'Layout: Form Controls',
+ 'Layout: HTML Frames', 'Layout: Images', 'Layout: Misc Code', 'Layout: R & A Pos', 'Layout: Tables', 'Layout: Text', 'Layout: View Rendering', 'MathML',
+ 'Networking', 'Networking: HTTP', 'Networking: Cookies', 'Networking: File', 'Networking: JAR', 'Networking: WebSockets', 'Networking: DNS', 'Selection',
+ 'Spelling Checker', 'Video/Audio', 'WebRTC', 'WebRTC: Audio/Video', 'SVG', 'WebRTC: Networking', 'WebRTC: Signalling', 'XML', 'XSLT']
+ - MailNews Core: ['Build Config']


### PR DESCRIPTION
I have one concern like how if the Core product with those components has > 100 bugs?
One suggestion would be to separate the Core product
```yaml
 - Core: ['CSS Parsing and Computation', 'DOM', 'DOM: Core & HTML', 'DOM: CSS Object Model']
 - Core: ['Spelling Checker', 'Video/Audio', 'WebRTC', 'WebRTC: Audio/Video', 'SVG']
```
We can separate it per previous project (build's query by itself, DOM & CSS by itself, etc), like:
```
- Core: ['CSS Parsing and Computation', 'SVG', 'DOM', 'DOM: Core & HTML', 'DOM: CSS Object Model', 'DOM: Device Interfaces', 'DOM: Events', 'DOM: IndexedDB', 'DOM: Mozilla Extensions', 'DOM: Other', 'DOM: Traversal-Range', 'DOM: Validation', 'DOM: Workers', 'Geolocation', 'HTML: Form Submission', 'Event Handling', 'HTML: Parser', 'MathML', 'XML', 'XSLT']
- Core: ['Editor', 'Selection', 'Keyboard: Navigation', 'Drag and Drop', 'Spelling Checker']
```
Do you think its needed?