### PR TITLE
Fix assigned bugs shown as unassigned

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -39,3 +39,4 @@ export const BUGZILLA_LANGUAGES = {
   XML: 'xml',
   XUL: 'xul',
 };
+export const BUGZILLA_UNASSIGNED = 'nobody@mozilla.org';

--- a/src/views/Languages/index.jsx
+++ b/src/views/Languages/index.jsx
@@ -17,6 +17,7 @@ import {
   MENTORED_BUG,
   BUGZILLA_PAGING_OPTIONS,
   BUGZILLA_SEARCH_OPTIONS,
+  BUGZILLA_UNASSIGNED,
 } from '../../utils/constants';
 import extractWhiteboardTags from '../../utils/extractWhiteboardTags';
 import projects from '../../data/loader';
@@ -262,7 +263,10 @@ export default class Languages extends Component {
         bugzillaData.goodFirst &&
         uniqBy(
           bugzillaData.goodFirst.edges.map(edge => edge.node).map(bug => ({
-            assignee: bug.status === 'ASSIGNED' ? bug.assignedTo.name : '-',
+            assignee:
+              bug.assignedTo.name !== BUGZILLA_UNASSIGNED
+                ? bug.assignedTo.name
+                : '-',
             project: bug.component,
             tags: [
               ...(bug.keywords || []),
@@ -281,7 +285,10 @@ export default class Languages extends Component {
         bugzillaData.mentored &&
         uniqBy(
           bugzillaData.mentored.edges.map(edge => edge.node).map(bug => ({
-            assignee: bug.status === 'ASSIGNED' ? bug.assignedTo.name : '-',
+            assignee:
+              bug.assignedTo.name !== BUGZILLA_UNASSIGNED
+                ? bug.assignedTo.name
+                : '-',
             project: bug.component,
             tags: [
               ...(bug.keywords || []),

--- a/src/views/Project/index.jsx
+++ b/src/views/Project/index.jsx
@@ -23,6 +23,7 @@ import {
   MENTORED_BUG,
   BUGZILLA_PAGING_OPTIONS,
   BUGZILLA_SEARCH_OPTIONS,
+  BUGZILLA_UNASSIGNED,
 } from '../../utils/constants';
 import extractWhiteboardTags from '../../utils/extractWhiteboardTags';
 import Dashboard from '../../components/Dashboard';
@@ -308,7 +309,10 @@ export default class Project extends Component {
         bugzillaData.goodFirst &&
         uniqBy(
           bugzillaData.goodFirst.edges.map(edge => edge.node).map(bug => ({
-            assignee: bug.status === 'ASSIGNED' ? bug.assignedTo.name : '-',
+            assignee:
+              bug.assignedTo.name !== BUGZILLA_UNASSIGNED
+                ? bug.assignedTo.name
+                : '-',
             project: bug.component,
             tags: [
               ...(bug.keywords || []),
@@ -327,7 +331,10 @@ export default class Project extends Component {
         bugzillaData.mentored &&
         uniqBy(
           bugzillaData.mentored.edges.map(edge => edge.node).map(bug => ({
-            assignee: bug.status === 'ASSIGNED' ? bug.assignedTo.name : '-',
+            assignee:
+              bug.assignedTo.name !== BUGZILLA_UNASSIGNED
+                ? bug.assignedTo.name
+                : '-',
             project: bug.component,
             tags: [
               ...(bug.keywords || []),
@@ -341,6 +348,10 @@ export default class Project extends Component {
           'summary'
         )) ||
       [];
+    const items = uniqBy(
+      [...issues, ...goodFirstBugs, ...mentoredBugs],
+      'summary'
+    );
 
     return (
       <Dashboard title={project.name}>
@@ -366,13 +377,7 @@ export default class Project extends Component {
         {error && <ErrorPanel error={error} />}
         {loading && <Spinner className={classes.spinner} />}
         {!loading && (
-          <TasksTable
-            onBugInfoClick={this.handleBugInfoClick}
-            items={uniqBy(
-              [...issues, ...goodFirstBugs, ...mentoredBugs],
-              'summary'
-            )}
-          />
+          <TasksTable onBugInfoClick={this.handleBugInfoClick} items={items} />
         )}
       </Dashboard>
     );


### PR DESCRIPTION
Change the assigned status determination not by the bug status but
by assignee name

Fix #195