### PR TITLE
Fix issue cant filter by tag with space

### DIFF
--- a/src/views/Project/index.jsx
+++ b/src/views/Project/index.jsx
@@ -60,6 +60,7 @@ const tagReposMapping = repositories =>
       fetchPolicy: 'network-only',
       variables: {
         searchQuery: '',
+        type: 'ISSUE',
       },
       context: {
         client: 'github',
@@ -220,6 +221,7 @@ export default class Project extends Component {
       query: githubInfoQuery,
       variables: {
         searchQuery,
+        type: 'ISSUE',
       },
       context: {
         client: 'github',

--- a/src/views/githubInfo.graphql
+++ b/src/views/githubInfo.graphql
@@ -1,4 +1,4 @@
-query githubInfo($searchQuery: String!, $type: SearchType = ISSUE) {
+query githubInfo($searchQuery: String!, $type: SearchType!) {
   search(first: 100, type: $type, query: $searchQuery){
     nodes {
       ... on Issue {


### PR DESCRIPTION
It is because the SearchType is a required variable, but we didnt put it as required thus it show `nullability mismatch error` which I think mean that the searchType isnt passed on to the query and it works in `/languages/:language` because in that query we specify the searchType instead of utilizing the default value, but then, if we set the default value with the required sign, we got `non-null variable $type cant have default value` , so i think we can just remove the default value and manually key in `type: ISSUE` on every query

https://github.com/octokit/octokit.graphql.net/issues/66#issuecomment-383971208

Fix #191