### PR TITLE
Fixes #199

### DIFF
--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -68,7 +68,7 @@ import Sidebar from '../../components/Sidebar';
       fill: theme.palette.common.white,
     },
   },
-  leftMargin: {
+  menuIconButton: {
     position: 'absolute',
     right: theme.spacing.unit,
   },
@@ -163,7 +163,7 @@ export default class Dashboard extends Component {
             <Hidden mdUp>
               <IconButton
                 className={classNames(classes.link, {
-                  [classes.leftMargin]: !header,
+                  [classes.menuIconButton]: !header,
                 })}
                 size="large"
                 onClick={this.handleDrawerToggle}>


### PR DESCRIPTION
Removes the overlapping of the back button and sidebar icon on mobile screens. 
The website will look in the following way  - 

![edit](https://user-images.githubusercontent.com/24795489/44629164-f5c7b900-a968-11e8-8062-edbd9e2d51f8.png)
