### PR TITLE
Fix dissymmetry in the appearance of "I'm feeling adventurous"

### DIFF
--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -100,6 +100,9 @@ const assignments = Object.values(ASSIGNEE);
     flex: 1,
     whiteSpace: 'nowrap',
   },
+  adventurousButton: {
+    paddingRight: 0,
+  },
   [theme.breakpoints.down('xs')]: {
     adventurousButton: {
       order: 2,

--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -72,6 +72,11 @@ const assignments = Object.values(ASSIGNEE);
   tableCell: {
     whiteSpace: 'nowrap',
   },
+  adventurousButton: {
+    '&:not(:hover)': {
+      paddingRight: 0,
+    },
+  },
   summaryItem: {
     marginLeft: -theme.spacing.unit,
     padding: theme.spacing.unit,
@@ -99,9 +104,6 @@ const assignments = Object.values(ASSIGNEE);
   title: {
     flex: 1,
     whiteSpace: 'nowrap',
-  },
-  adventurousButton: {
-    paddingRight: 0,
   },
   [theme.breakpoints.down('xs')]: {
     adventurousButton: {

--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -72,11 +72,6 @@ const assignments = Object.values(ASSIGNEE);
   tableCell: {
     whiteSpace: 'nowrap',
   },
-  adventurousButton: {
-    '&:not(:hover)': {
-      paddingRight: 0,
-    },
-  },
   summaryItem: {
     marginLeft: -theme.spacing.unit,
     padding: theme.spacing.unit,
@@ -309,6 +304,7 @@ export default class TasksTable extends Component {
             Bugs & Issues
           </Typography>
           <Button
+            variant="outlined"
             color="primary"
             disabled={!items.length}
             onClick={this.handleRandomTaskClick}


### PR DESCRIPTION
Removed the right padding of **I'm feeling adventurous** element, henceforth, enhancing the website's look by adding symmetry. 

Padding around the element - 

![solved](https://user-images.githubusercontent.com/24795489/44685604-7372ee00-aa69-11e8-8f5a-54129476ea3e.png)

Final appearance -

![screen shot 2018-08-28 at 2 20 20 am](https://user-images.githubusercontent.com/24795489/44685573-6524d200-aa69-11e8-82a5-80af479c4d61.png)


