### PR TITLE
Update the appearance of adventureButton on smaller screens

### DIFF
--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -100,9 +100,13 @@ const assignments = Object.values(ASSIGNEE);
     flex: 1,
     whiteSpace: 'nowrap',
   },
-  [theme.breakpoints.down('xs')]: {
+  [theme.breakpoints.down('sm')]: {
     adventurousButton: {
       order: 2,
+      margin: `${theme.spacing.unit}px 0`,
+    },
+    toolbar: {
+      justifyContent: 'flex-start',
     },
   },
   icon: {


### PR DESCRIPTION
Updated the appearance of adventureButton on smaller screens. 
It will now appear in the following way -

![44857355-a4a41780-ac3d-11e8-9f37-d007ca4be335](https://user-images.githubusercontent.com/24795489/44876084-a31a3400-acbd-11e8-8fef-b8f5e53189b9.png)
