### PR TITLE
Fix XUL language query returns improper bugs

### DIFF
--- a/src/views/Languages/index.jsx
+++ b/src/views/Languages/index.jsx
@@ -176,7 +176,11 @@ export default class Languages extends Component {
       (githubData &&
         githubData.search &&
         githubData.search.nodes
-          .filter(repository => repository.primaryLanguage)
+          .filter(
+            repository =>
+              repository.primaryLanguage &&
+              repository.primaryLanguage.name.toLowerCase().includes(language)
+          )
           .reduce(
             (repositories, repository) => [
               ...repositories,


### PR DESCRIPTION
XUL Language is not one of the languages enum in Github, and the
Graphql behavior is that it will return back all repositories
instead of empty repository in that case. We initially just
check if the primary language exist, without checking the value inside

Fix #225