### PR TITLE
Update webextensions.yaml

### DIFF
--- a/src/data/webextensions.yaml
+++ b/src/data/webextensions.yaml
@@ -1,4 +1,18 @@
-name: Firefox - Web Extensions
-icon: plus
+name: Firefox - WebExtensions
+summary: APIs to build Firefox extensions and themes.
+introduction: |
+  ## About WebExtensions
+
+  WebExtensions are add-ons that users can install to modify the behavior of Firefox.
+  The APIs and tools to support these add-ons are developed by the WebExtensions team.
+
+  ## How Do I Get Started?
+
+  To get started with contributing to the WebExtensions API, see https://wiki.mozilla.org/Add-ons/Contribute#Contribute_to_the_WebExtensions_API .
+
+  ## How Do I Get Help?
+
+  We are available on [IRC](https://wiki.mozilla.org/IRC) in the `#webextensions` channel.
+
 products: 
- - Toolkit: ['WebExtensions: Android', 'WebExtensions: Compatibility', 'WebExtensions: Developer tools', 'WebExtensions: Experiments', 'WebExtensions: Frontend', 'WebExtensions: General', 'WebExtensions: Request Handling', 'WebExtensions: Untriaged']
+ - WebExtensions

--- a/src/images/projectIcons/webextensions.svg
+++ b/src/images/projectIcons/webextensions.svg
@@ -1,0 +1,12 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="gradient-linear-puzzle-piece" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#66cc52" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#60bf4c" stop-opacity="1"/>
+    </linearGradient>
+  </defs>
+  <path fill="url('#gradient-linear-puzzle-piece')" d="M42,62c2.2,0,4-1.8,4-4l0-14.2c0,0,0.4-3.7,2.8-3.7c2.4,0,2.2,3.9,6.7,3.9c2.3,0,6.2-1.2,6.2-8.2 c0-7-3.9-7.9-6.2-7.9c-4.5,0-4.3,3.7-6.7,3.7c-2.4,0-2.8-3.8-2.8-3.8V22c0-2.2-1.8-4-4-4H31.5c0,0-3.4-0.6-3.4-3 c0-2.4,3.8-2.6,3.8-7.1c0-2.3-1.3-5.9-8.3-5.9s-8,3.6-8,5.9c0,4.5,3.4,4.7,3.4,7.1c0,2.4-3.4,3-3.4,3H6c-2.2,0-4,1.8-4,4l0,7.8 c0,0-0.4,6,4.4,6c3.1,0,3.2-4.1,7.3-4.1c2,0,4,1.9,4,6c0,4.2-2,6.3-4,6.3c-4,0-4.2-4.1-7.3-4.1c-4.8,0-4.4,5.8-4.4,5.8L2,58 c0,2.2,1.8,4,4,4H19c0,0,6.3,0.4,6.3-4.4c0-3.1-4-3.6-4-7.7c0-2,2.2-4.5,6.4-4.5c4.2,0,6.6,2.5,6.6,4.5c0,4-3.9,4.6-3.9,7.7 c0,4.9,6.3,4.4,6.3,4.4H42z"/>
+</svg>


### PR DESCRIPTION
The BMO categories were out-of-date because WebExtensions was moved to a new product a few months ago.

This PR fixes that issue, and also adds a summary, introduction and icon.