### PR TITLE
Sort projects dropdown (#255)

### DIFF
--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -299,7 +299,15 @@ export default class TasksTable extends Component {
       project
     );
     const iconSize = 14;
-    const projects = [...new Set(items.map(item => item.project))];
+    const projects = [
+      ...new Set(
+        items
+          .map(item => item.project)
+          .sort((a, b) =>
+            a.localeCompare(b, undefined, { sensitivity: 'base' })
+          )
+      ),
+    ];
 
     return (
       <Fragment>


### PR DESCRIPTION
Hoping to resolve #255.

If compatibility < IE11 is needed, I can switch to using toLowerCase() instead of localeCompare()'s built-in options.

**Note:** I closed the previous pull request as I couldn't figure out how to re-run the failed checks after amending the commit. Apologies if this wasn't the right way to handle it.