### PR TITLE
Add wpt-api's 'good first issue' label to query

### DIFF
--- a/src/data/automation.yaml
+++ b/src/data/automation.yaml
@@ -1,8 +1,8 @@
 name: Test Automation
 icon: test-tube
-products: 
+products:
  - Testing
-repositories: 
+repositories:
  - armenzg/mozilla_ci_tools: mentored
  - automatedtester/automation-services-bot: mentored
  - automatedtester/powerball-platform: mentored
@@ -22,3 +22,4 @@ repositories:
  - mozilla/release-services: skill:good-first-bug
  - mozilla/firefox-code-coverage-frontend: 'good first issue'
  - mozilla/coverage-crawler: 'good first issue'
+ - mozilla/wpt-api: 'good first issue'


### PR DESCRIPTION
Should address https://github.com/mozilla/wpt-api/issues/250

(Note to self: noticed some other cleanup, so patched https://github.com/mozilla-frontend-infra/codetribute/pull/287 - removing outdated/decommissioned repos.)