### PR TITLE
Update application services label

### DIFF
--- a/src/data/applicationservices.yaml
+++ b/src/data/applicationservices.yaml
@@ -2,4 +2,4 @@ name: Application Services
 summary: Application Services is a platform for building cloud-powered applications that target Firefox users.
 icon: cloud-sync
 repositories:
-- mozilla/application-services: 'good first issue'
+- mozilla/application-services: ['good-first-issue', 'good-second-issue']


### PR DESCRIPTION
The tags didn't link up properly due to the previous space instead of hyphens. Also added good second issues.