### PR TITLE
Revert "Allow projects to merge into one label"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,6 @@ introduction: |
 products:
 - <Bugzilla Product>
 - <Bugzilla Product>: ['<Bugzilla Component 1>', '<Bugzilla Component 2>']
-# to include multiple products or components under a single label in the "Projects" menu, or customize the label:
-- label: <Project Label shown in the dropdown, to change/group the label from the default value which is the component name>
-  products:
-  - <Bugzilla Product>
-  - <Bugzilla Product>: ['<Bugzilla Component 1>', '<Bugzilla Component 2>'] 
 repositories:
 - <Organization Name>/<Repository Name> : <Github Label>
 - <Organization Name>/<Repository Name> : ['<Github Label 1>', '<Github Label 2>']

--- a/src/components/TasksTable/index.jsx
+++ b/src/components/TasksTable/index.jsx
@@ -192,9 +192,7 @@ export default class TasksTable extends Component {
         .filter(
           item =>
             (!tag || item.tags.includes(tag)) &&
-            (!project ||
-              project === ALL_PROJECTS ||
-              item.projectLabels.includes(project))
+            (!project || project === ALL_PROJECTS || item.project === project)
         )
         .sort((a, b) => {
           const firstElement =
@@ -308,7 +306,7 @@ export default class TasksTable extends Component {
     const projects = [
       ...new Set(
         items
-          .reduce((prev, item) => [...prev, ...item.projectLabels], [])
+          .map(item => item.project)
           .sort((a, b) =>
             a.localeCompare(b, undefined, { sensitivity: 'base' })
           )

--- a/src/utils/isStringEqualIgnoreCase.js
+++ b/src/utils/isStringEqualIgnoreCase.js
@@ -1,9 +1,0 @@
-/**
- * Return true if two string is equal, case insensitive.
- */
-
-const isStringEqualIgnoreCase = (a, b) => {
-  return a.toLowerCase() === b.toLowerCase();
-};
-
-export default isStringEqualIgnoreCase;

--- a/src/views/Languages/index.jsx
+++ b/src/views/Languages/index.jsx
@@ -270,7 +270,6 @@ export default class Languages extends Component {
                 : '-',
               url: issue.url,
               description: issue.body,
-              projectLabels: [issue.repository.name],
             })),
           'summary'
         )) ||
@@ -296,7 +295,6 @@ export default class Languages extends Component {
               lastUpdated: bug.lastChanged,
               id: bug.id,
               url: `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`,
-              projectLabels: [bug.component],
             })),
           'summary'
         )) ||
@@ -322,7 +320,6 @@ export default class Languages extends Component {
               lastUpdated: bug.lastChanged,
               id: bug.id,
               url: `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`,
-              projectLabels: [bug.component],
             })),
           'summary'
         )) ||

--- a/src/views/Project/index.jsx
+++ b/src/views/Project/index.jsx
@@ -2,7 +2,7 @@ import { hot } from 'react-hot-loader';
 import React, { Component } from 'react';
 import { graphql, compose, withApollo } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
-import { mergeAll, memoizeWith, mergeWith, concat } from 'ramda';
+import { mergeAll, memoizeWith } from 'ramda';
 import uniqBy from 'lodash.uniqby';
 import { withStyles } from '@material-ui/core/styles';
 import projects from '../../data/loader';
@@ -19,18 +19,9 @@ import {
   BUGZILLA_SEARCH_OPTIONS,
   BUGZILLA_UNASSIGNED,
 } from '../../utils/constants';
-import isStringEqualIgnoreCase from '../../utils/isStringEqualIgnoreCase';
 import extractWhiteboardTags from '../../utils/extractWhiteboardTags';
 import Dashboard from '../../components/Dashboard';
 import ProjectIntroductionCard from '../../components/ProjectIntroductionCard';
-
-const getProductsInfoWithoutLabel = products => {
-  return products.reduce(
-    (prev, product) =>
-      product.label ? [...prev, ...product.products] : [...prev, product],
-    []
-  );
-};
 
 const productsWithNoComponents = products =>
   products.filter(product => typeof product === 'string');
@@ -51,40 +42,6 @@ const tagReposMapping = repositories =>
       ...mappings,
     };
   }, {});
-const getProjectLabels = memoizeWith(
-  (...args) => args.join('-'),
-  (projectName, bugProduct, bugComponent) => {
-    // A bug might have multiple labels when one of the entries only doesn't
-    // specify product name
-    const relatedProductQueriesWithLabel = (
-      projects[projectName].products || []
-    ).filter(
-      query =>
-        !!query.label &&
-        query.products.some(innerProduct => {
-          if (typeof innerProduct === 'string') {
-            return isStringEqualIgnoreCase(bugProduct, innerProduct);
-          }
-
-          if (
-            isStringEqualIgnoreCase(bugProduct, Object.keys(innerProduct)[0])
-          ) {
-            const innerComponents = Object.values(innerProduct)[0];
-
-            return innerComponents.some(component =>
-              isStringEqualIgnoreCase(component, bugComponent)
-            );
-          }
-
-          return false;
-        })
-    );
-
-    return relatedProductQueriesWithLabel.length
-      ? relatedProductQueriesWithLabel.map(q => q.label)
-      : [bugComponent];
-  }
-);
 
 @hot(module)
 @compose(
@@ -117,51 +74,45 @@ const getProjectLabels = memoizeWith(
       match: {
         params: { project },
       },
-    }) => {
-      const productsInfo = getProductsInfoWithoutLabel(
-        projects[project].products
-      );
-
-      return {
-        fetchPolicy: 'network-only',
-        variables: {
-          goodFirst: {
-            ...BUGZILLA_SEARCH_OPTIONS,
-            keywords: [GOOD_FIRST_BUG],
-            // get all the product with no component as it can be
-            // merged as an OR query if it exists
-            ...(productsWithNoComponents(productsInfo).length
-              ? { products: productsWithNoComponents(productsInfo) }
-              : {
-                  // otherwise, get only the first product and its components
-                  // as component is not unique for product thus can't be merged
-                  products: Object.keys(productsInfo[0])[0],
-                  components: Object.values(productsInfo[0])[0],
-                }),
-          },
-          mentored: {
-            ...BUGZILLA_SEARCH_OPTIONS,
-            ...MENTORED_BUG,
-            // get all the product with no component as it can be
-            // merged as an OR query if it exists
-            ...(productsWithNoComponents(productsInfo).length
-              ? { products: productsWithNoComponents(productsInfo) }
-              : {
-                  // otherwise, get only the first product and its components
-                  // as component is not unique for product thus can't be merged
-                  products: Object.keys(productsInfo[0])[0],
-                  components: Object.values(productsInfo[0])[0],
-                }),
-          },
-          paging: {
-            ...BUGZILLA_PAGING_OPTIONS,
-          },
+    }) => ({
+      fetchPolicy: 'network-only',
+      variables: {
+        goodFirst: {
+          ...BUGZILLA_SEARCH_OPTIONS,
+          keywords: [GOOD_FIRST_BUG],
+          // get all the product with no component as it can be
+          // merged as an OR query if it exists
+          ...(productsWithNoComponents(projects[project].products).length
+            ? { products: productsWithNoComponents(projects[project].products) }
+            : {
+                // otherwise, get only the first product and its components
+                // as component is not unique for product thus can't be merged
+                products: Object.keys(projects[project].products[0])[0],
+                components: Object.values(projects[project].products[0])[0],
+              }),
         },
-        context: {
-          client: 'bugzilla',
+        mentored: {
+          ...BUGZILLA_SEARCH_OPTIONS,
+          ...MENTORED_BUG,
+          // get all the product with no component as it can be
+          // merged as an OR query if it exists
+          ...(productsWithNoComponents(projects[project].products).length
+            ? { products: productsWithNoComponents(projects[project].products) }
+            : {
+                // otherwise, get only the first product and its components
+                // as component is not unique for product thus can't be merged
+                products: Object.keys(projects[project].products[0])[0],
+                components: Object.values(projects[project].products[0])[0],
+              }),
         },
-      };
-    },
+        paging: {
+          ...BUGZILLA_PAGING_OPTIONS,
+        },
+      },
+      context: {
+        client: 'bugzilla',
+      },
+    }),
   })
 )
 @withApollo
@@ -303,12 +254,11 @@ export default class Project extends Component {
         return this.fetchGithub(searchQuery);
       })
     );
-    const productInfos = getProductsInfoWithoutLabel(project.products);
-    const productWithComponentList = productInfos
-      ? productInfos
-          .filter(product => typeof product !== 'string')
-          .reduce((prev, product) => mergeWith(concat, prev, product), {})
-      : {};
+    const productWithComponentList = mergeAll(
+      project.products
+        ? project.products.filter(product => typeof product !== 'string')
+        : []
+    );
 
     // fetch only the product with component list, since product without
     // component would have been fetched by the initial graphql decorator query
@@ -340,7 +290,6 @@ export default class Project extends Component {
               : '-',
             url: issue.url,
             description: issue.body,
-            projectLabels: [issue.repository.name],
           })),
           'summary'
         )) ||
@@ -367,11 +316,6 @@ export default class Project extends Component {
               lastUpdated: bug.lastChanged,
               id: bug.id,
               url: `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`,
-              projectLabels: getProjectLabels(
-                this.props.match.params.project,
-                bug.product,
-                bug.component
-              ),
             })),
           'summary'
         )) ||
@@ -397,11 +341,6 @@ export default class Project extends Component {
               lastUpdated: bug.lastChanged,
               id: bug.id,
               url: `https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`,
-              projectLabels: getProjectLabels(
-                this.props.match.params.project,
-                bug.product,
-                bug.component
-              ),
             })),
           'summary'
         )) ||

--- a/src/views/bugs.graphql
+++ b/src/views/bugs.graphql
@@ -19,7 +19,6 @@ fragment Bugs on BugPager {
       keywords
       summary
       whiteboard
-      product
     }
   }
 }


### PR DESCRIPTION
Reverts mozilla-frontend-infra/codetribute#399

Refer to https://github.com/mozilla-frontend-infra/codetribute/issues/405 for why we are reverting.