### PR TITLE
Update outdated links and information for devtools

### DIFF
--- a/src/data/devtools.yaml
+++ b/src/data/devtools.yaml
@@ -22,16 +22,13 @@ introduction: |
   If you intend to work on a bug (in [Bugzilla](https://bugzilla.mozilla.org)) or an issue (in [GitHub](https://github.com)), make sure you have an account on those sites.
 
   Comment in the bug or issue and say that you are interesting in working on it. Ask any questions you may have. And make sure you do your research.
-  Look the other comments, look at [the documentation](https://docs.firefox-dev.tools/) and [source code](https://searchfox.org/mozilla-central/source/devtools), and try to figure out as much as you can first.
+  Look at the other comments, look at [the documentation](https://firefox-source-docs.mozilla.org) and [source code](https://searchfox.org/mozilla-central/source/devtools), and try to figure out as much as you can first.
 
   ### How Do I Write the Code?
 
-  Most of the code is hosted in the Firefox repository (called `mozilla-central`), while some pieces are developed on GitHub.
-  You can learn more about where the code is by reading [the documentation](https://docs.firefox-dev.tools/getting-started/where-is-the-code.html).
-
-  Once you've figured out what you would like to work on, read about [how to set up your local development environment](https://docs.firefox-dev.tools/getting-started/build.html).
-
-  Finally, [create and send a patch](https://docs.firefox-dev.tools/contributing/making-prs.html) for someone else to review and merge in the repository.
+  The Firefox DevTools code is hosted in the Firefox repository (called `mozilla-central`), see the [contributor documentation](https://firefox-source-docs.mozilla.org/devtools/index.html).
+  
+  The Firefox Profiler frontend is maintained on GitHub. Checkout the [repository](https://github.com/firefox-devtools/profiler/) to retrieve the code and read the documentation.
 
   ## How Do I Get Help?
 


### PR DESCRIPTION
Links were pointing at the old documentation.
Some information was confusing, hinting a DevTools being developed on GitHub while only the profiler is still there.