### PR TITLE
Separate our developer infrastructure to a separate section.

### DIFF
--- a/src/data/ff-build.yaml
+++ b/src/data/ff-build.yaml
@@ -1,9 +1,7 @@
-name: Firefox - Development Environment
-summary: The harnesses, code analysis, and linting tools surrounding the building of Firefox.
+name: Firefox - Development Build System Environment
+summary: The harnesses tools surrounding the building of Firefox.
 icon: package-variant
 introduction: |
   The development environment (aka build system) supports the building of Firefox.
-
-  This area also covers tools for building documentation, code analysis and linting.
 products:
  - "Firefox Build System"

--- a/src/data/ff-infra.yaml
+++ b/src/data/ff-infra.yaml
@@ -1,0 +1,11 @@
+name: Firefox - Development Infrastructure
+summary: All the linting tools, code analysis, editor integration, source documentation infrastructure that supports Firefox developers.
+icon: package-variant
+introduction: |
+  These tools are a vital part of the developer support system for Firefox.
+
+  They help provide the linting and code analysis tools that reduce errors in the
+  code and provide consistent formatting. They also help with editor integration,
+  generating source documentation and more.
+products:
+ - "Developer Infrastructure"


### PR DESCRIPTION
Some of the lint/source docs and other items just got [moved into a different project in bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1784867).

This PR is to add a new section for the new parts and make the build system section a little clearer.