### PR TITLE
Replace `rls` with `rust-analyser`

### DIFF
--- a/src/data/rls.yaml
+++ b/src/data/rls.yaml
@@ -1,5 +1,0 @@
-name: Rust Language Server
-summary: RLS is the IDE integration plugin for Rust
-icon: server
-repositories: 
- - rust-lang/rls: good first issue

--- a/src/data/rust-analyser.yaml
+++ b/src/data/rust-analyser.yaml
@@ -1,0 +1,5 @@
+name: Rust Analyser
+summary: A Rust compiler front-end for IDEs
+icon: server
+repositories: 
+ - rust-lang/rust-analyser: good first issue


### PR DESCRIPTION
`rls` has been deprecated and is no longer supported. It has been replaced with `rust-analyser`.

Closes #604